### PR TITLE
Windows - Error in directory list fetch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <openrefine.version>3.9-beta1</openrefine.version>
+    <openrefine.version>3.8.7</openrefine.version>
     <!-- Change the values below, as well as the groupId & url, to reflect your extension -->
     <extension.id>openrefine-files-extension</extension.id>
     <extension.name>OpenRefine Files Extension</extension.name>

--- a/src/main/java/org/openrefine/extensions/files/importer/FilesImportingController.java
+++ b/src/main/java/org/openrefine/extensions/files/importer/FilesImportingController.java
@@ -82,7 +82,7 @@ public class FilesImportingController implements ImportingController {
 
     private void getDirectoryHierarchy(HttpServletRequest request, HttpServletResponse response, Properties parameters) throws ServletException, IOException {
         String dirPath = parameters.getProperty("dirPath");
-        String fileName = "directoryList_OR_".concat(Instant.now().toString());
+        String fileName = "directoryList_OR_".concat(Instant.now().toString().replace(":", ""));
         Path outputFile = Files.createTempFile(fileName, ".json");
         FilesImporter.generateDirectoryTree(dirPath, outputFile);
         respondJSON(response, Files.readString(outputFile));


### PR DESCRIPTION
Issue #14 
On Windows directory listing  API fails due to unsupported char colon : in the temporary file name. Removed colon character from timestamp