### PR TITLE
Update to OR 3.9.0 and narrow dependencies to the core artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <openrefine.version>3.8.7</openrefine.version>
+    <openrefine.version>3.9.0</openrefine.version>
     <!-- Change the values below, as well as the groupId & url, to reflect your extension -->
     <extension.id>openrefine-files-extension</extension.id>
     <extension.name>OpenRefine Files Extension</extension.name>
@@ -105,7 +105,7 @@
   <dependencies>
      <dependency>
       <groupId>org.openrefine</groupId>
-      <artifactId>main</artifactId>
+      <artifactId>core</artifactId>
       <version>${openrefine.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -126,7 +126,7 @@
     </dependency>
     <dependency>
       <groupId>org.openrefine</groupId>
-      <artifactId>main</artifactId>
+      <artifactId>core</artifactId>
       <version>${openrefine.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
   <dependencies>
      <dependency>
       <groupId>org.openrefine</groupId>
-      <artifactId>core</artifactId>
+      <artifactId>main</artifactId>
       <version>${openrefine.version}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
This PR demonstrates how to update to OpenRefine 3.9, as an example for other extensions (I'm writing a forum post about that).